### PR TITLE
Use bash -s and HEREDOC instead of bash -c so we don't have to escape quotes

### DIFF
--- a/.github/workflows/failure-tests.yml
+++ b/.github/workflows/failure-tests.yml
@@ -2,9 +2,7 @@ name: Failure Tests
 on:
   push:
     branches: [ release/*, develop ]
-
 jobs:
-  
   one:
     runs-on: [self-hosted, macOS]
     steps:
@@ -12,32 +10,33 @@ jobs:
         id: command-failure
         uses: ./
         with:
-          anka-template: "10.15.4"
+          anka-template: "10.15.5"
           anka-tag: "base"
           anka-run-options: "-n"
-          commands: "java -version"
+          commands: "java -version || if [ \\$? -gt 0 ]; then echo failed; else exit 20; fi"
   two:
-    runs-on: [self-hosted, macOS]
-    steps:
-      - name: bad host command option
-        id: bad-host-command-option
-        uses: ./
-        with:
-          anka-template: "10.15.4"
-          anka-tag: "base"
-          anka-run-options: "-n"
-          host-command-options: "1231!!"
-          commands: "echo 123"
-  three:
     runs-on: [self-hosted, macOS]
     steps:
       - name: multi-line commands failure
         id: multi-line-commands-failure
         uses: ./
         with:
-          anka-template: "10.15.4"
+          anka-template: "10.15.5"
           anka-tag: "base"
           anka-run-options: "-n"
           commands: |
             echo 123
-            java -version
+            java -version || if [ \$? -gt 0 ]; then echo failed; else exit 20; fi
+  # Cannot throw a pass if it fails so we'll just use a unit test for now
+  # two:
+  #   runs-on: [self-hosted, macOS]
+  #   steps:
+  #     - name: bad host command option
+  #       id: bad-host-command-option
+  #       uses: ./
+  #       with:
+  #         anka-template: "10.15.5"
+  #         anka-tag: "base"
+  #         anka-run-options: "-n"
+  #         host-command-options: "1231!!"
+  #         commands: "echo 123"

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -14,10 +14,10 @@ jobs:
         uses: ./
         with:
           anka-registry-pull-options: "-s" # Needed to remove other cached tags and cause openjdk pull to take a while so we can test the Lock file
-          anka-template: "10.15.4"
+          anka-template: "10.15.5"
           anka-tag: "base"
           anka-run-options: "-n"
-          commands: "echo \"123\""
+          commands: ""
 
   functional-tests:
     runs-on: [self-hosted, macOS]
@@ -29,7 +29,7 @@ jobs:
         uses: ./
         with:
           host-pre-commands: "env"
-          anka-template: "10.15.4"
+          anka-template: "10.15.5"
           anka-tag: "base:port-forward-22:brew-git:openjdk-1.8.0_242"
           commands: "echo 123"
 
@@ -37,13 +37,20 @@ jobs:
         id: basic
         uses: ./
         with:
-          anka-template: "10.15.4"
+          anka-template: "10.15.5"
           anka-tag: "base:port-forward-22:brew-git"
           host-post-commands: "env"
           commands: |
             env
             ls -laht ./
             ls -laht ../
+            cat << EOF > /tmp/yourfilehere
+            test"1 23"
+            \\\$(echo $HOME)
+            \\\$(echo \$HOME)
+            \\\$(echo \\\$HOME)
+            EOF
+            cat /tmp/yourfilehere
             pwd
             echo "HERE" && \
             echo "THERE HERE WHERE"
@@ -52,7 +59,7 @@ jobs:
         id: chained-redirect
         uses: ./
         with:
-          anka-template: "10.15.4"
+          anka-template: "10.15.5"
           commands: "hostname && echo \"test1\" && echo \"Test2\" > /tmp/test && cat /tmp/test"
 
       - name: script execution with args
@@ -60,7 +67,7 @@ jobs:
         uses: ./
         with:
           anka-run-options: "--wait-network --wait-time"
-          anka-template: "10.15.4"
+          anka-template: "10.15.5"
           anka-tag: "base"
           commands: "hostname && ./test.bash 1 2 3 4"
 
@@ -68,7 +75,7 @@ jobs:
         id: inputs-testing
         uses: ./
         with:
-          anka-template: "10.15.4"
+          anka-template: "10.15.5"
           anka-tag: "DOESNOTEXIST"
           skip-registry-pull: true
           anka-custom-vm-label: "custom-label-${GITHUB_RUN_NUMBER}"
@@ -95,7 +102,7 @@ jobs:
         id: artifacts-1
         uses: ./
         with:
-          anka-template: "10.15.4"
+          anka-template: "10.15.5"
           anka-tag: base
           anka-custom-vm-label: "custom-label-${GITHUB_RUN_NUMBER}"
           commands: |
@@ -118,52 +125,57 @@ jobs:
       # Must single quote output in run: due to quotes in commands: (basic)
       - name: Check for output (testing anything execute.test.js doesn't)
         run: |
-          PULL_TEST_PREP_TWO_STD='${{ steps.pull-test-prep-2.outputs.std }}'
-          printf "\n=======================\npull-test-prep-2 std\n========================\n$PULL_TEST_PREP_TWO_STD"
-          [[ ! -z "$(echo \"$PULL_TEST_PREP_TWO_STD\" | head -n 1)" ]] || exit 1
-          [[ ! -z "$(echo \"$PULL_TEST_PREP_TWO_STD\"  | grep '(base:port-forward-22:brew-git:openjdk-1.8.0_242)')" ]] || exit 3
-          [[ ! -z "$(echo \"$PULL_TEST_PREP_TWO_STD\"  | grep 'self1_isPost=true')" ]] || exit 4
-          [[ -z "$(echo \"$PULL_TEST_PREP_TWO_STD\"  | grep 'self1_isCreated')" ]] || exit 5
-          [[ -z "$(echo \"$PULL_TEST_PREP_TWO_STD\"  | grep 'self1_isLocked')" ]] || exit 6
-
           BASIC_STD='${{ steps.basic.outputs.std }}'
           printf "\n=======================\nbasic std\n========================\n$BASIC_STD"
-          [[ ! -z "$(echo \"$BASIC_STD\" | head -n 1)" ]] || exit 10
-          [[ -z "$(echo \"$BASIC_STD\" | grep 'base:port-forward-22:brew-git:openjdk-')" ]] || exit 11
-          [[ ! -z "$(echo \"$BASIC_STD\" | grep '(base:port-forward-22:brew-git)')" ]] || exit 12
-          [[ ! -z "$(echo \"$BASIC_STD\" | grep 'self2_isPost=true')" ]] || exit 13
-          [[ ! -z "$(echo \"$BASIC_STD\"| grep 'self2_isCreated=true')" ]] || exit 14
-          [[ ! -z "$(echo \"$BASIC_STD\" | grep 'self2_isLocked=false')" ]] || exit 15
-      
+          [[ ! -z "$(echo \\"$BASIC_STD\\" | head -n 1)" ]] || exit 10
+          [[ -z "$(echo \\"$BASIC_STD\\" | grep 'base:port-forward-22:brew-git:openjdk-')" ]] || exit 11
+          [[ ! -z "$(echo \\"$BASIC_STD\\" | grep '(base:port-forward-22:brew-git)')" ]] || exit 12
+          [[ ! -z "$(echo \\"$BASIC_STD\\" | grep 'self2_isPost=true')" ]] || exit 13
+          [[ ! -z "$(echo \\"$BASIC_STD\\"| grep 'self2_isCreated=true')" ]] || exit 14
+          [[ ! -z "$(echo \\"$BASIC_STD\\" | grep 'self2_isLocked=false')" ]] || exit 15
+          [[ ! -z "$(echo \\"$BASIC_STD\\" | grep '^$(echo /Users/anka)')" ]] || exit 16
+          [[ ! -z "$(echo \\"$BASIC_STD\\" | grep '^$(echo $HOME)')" ]] || exit 17
+          [[ ! -z "$(echo \\"$BASIC_STD\\" | grep '^$(echo /Users/' | grep -v anka)" ]] || exit 18
+          true
+
+          PULL_TEST_PREP_TWO_STD='${{ steps.pull-test-prep-2.outputs.std }}'
+          printf "\n=======================\npull-test-prep-2 std\n========================\n$PULL_TEST_PREP_TWO_STD"
+          [[ ! -z "$(echo \\"$PULL_TEST_PREP_TWO_STD\\" | head -n 1)" ]] || exit 1
+          [[ -z "$(echo \\"$PULL_TEST_PREP_TWO_STD\\"  | grep '/Users/anka')" ]] || exit 2
+          [[ ! -z "$(echo \\"$PULL_TEST_PREP_TWO_STD\\"  | grep '(base:port-forward-22:brew-git:openjdk-1.8.0_242)')" ]] || exit 3
+          [[ ! -z "$(echo \\"$PULL_TEST_PREP_TWO_STD\\"  | grep 'self1_isPost=true')" ]] || exit 4
+          [[ -z "$(echo \\"$PULL_TEST_PREP_TWO_STD\\"  | grep 'self1_isCreated')" ]] || exit 5
+          [[ -z "$(echo \\"$PULL_TEST_PREP_TWO_STD\\"  | grep 'self1_isLocked')" ]] || exit 6
+
           CHAINED_REDIRECT_STD='${{ steps.chained-redirect.outputs.std }}'
           printf "\n=======================\nchained-redirect stdout\n========================\n$CHAINED_REDIRECT_STD"
-          [[ ! -z "$(echo \"$CHAINED_REDIRECT_STD\" | head -n 1)" ]] || exit 20
+          [[ ! -z "$(echo \\"$CHAINED_REDIRECT_STD\\" | head -n 1)" ]] || exit 20
 
           SCRIPT_AND_ARGS_STD='${{ steps.script-and-args.outputs.std }}'
           printf "\n=======================\nscript-and-args stdout\n========================\n$SCRIPT_AND_ARGS_STD"
-          [[ ! -z "$(echo \"$SCRIPT_AND_ARGS_STD\" | head -n 1)" ]] || exit 30
-          [[ ! -z "$(echo \"$SCRIPT_AND_ARGS_STD\" | grep '| 10.15.4 (base)')" ]] || exit 31
+          [[ ! -z "$(echo \\"$SCRIPT_AND_ARGS_STD\\" | head -n 1)" ]] || exit 30
+          [[ ! -z "$(echo \\"$SCRIPT_AND_ARGS_STD\\" | grep '| 10.15.5 (base)')" ]] || exit 31
 
           INPUTS_TESTING_STD='${{ steps.inputs-testing.outputs.std }}'
           printf "\n=======================\ninputs-testing stdout\n========================\n$INPUTS_TESTING_STD"
-          [[ ! -z "$(echo \"$INPUTS_TESTING_STD\" | head -n 1)" ]] || exit 40
-          [[ ! -z "$(echo \"$INPUTS_TESTING_STD\" | grep 'PRE COMMANDS')" ]] || exit 41
-          [[ ! -z "$(echo \"$INPUTS_TESTING_STD\" | grep 'POST COMMANDS')" ]] || exit 42
-          [[ ! -z "$(echo \"$INPUTS_TESTING_STD\" | grep '| custom-label-')" ]] || exit 43
-          [[ ! -z "$(echo \"$INPUTS_TESTING_STD\" | grep 'CWD: /private/tmp')" ]] || exit 44
-          [[ ! -z "$(echo \"$INPUTS_TESTING_STD\" | grep 'PWD=/private/tmp')" ]] || exit 45
-          [[ ! -z "$(echo \"$INPUTS_TESTING_STD\"  | grep 'self5_isPost=true')" ]] || exit 46
-          [[ -z "$(echo \"$INPUTS_TESTING_STD\"  | grep 'self5_isCreated')" ]] || exit 47
-          [[ -z "$(echo \"$INPUTS_TESTING_STD\"  | grep 'self5_isLocked')" ]] || exit 48
+          [[ ! -z "$(echo \\"$INPUTS_TESTING_STD\\" | head -n 1)" ]] || exit 40
+          [[ ! -z "$(echo \\"$INPUTS_TESTING_STD\\" | grep 'PRE COMMANDS')" ]] || exit 41
+          [[ ! -z "$(echo \\"$INPUTS_TESTING_STD\\" | grep 'POST COMMANDS')" ]] || exit 42
+          [[ ! -z "$(echo \\"$INPUTS_TESTING_STD\\" | grep '| custom-label-')" ]] || exit 43
+          [[ ! -z "$(echo \\"$INPUTS_TESTING_STD\\" | grep 'CWD: /private/tmp')" ]] || exit 44
+          [[ ! -z "$(echo \\"$INPUTS_TESTING_STD\\" | grep 'PWD=/private/tmp')" ]] || exit 45
+          [[ ! -z "$(echo \\"$INPUTS_TESTING_STD\\"  | grep 'self5_isPost=true')" ]] || exit 46
+          [[ -z "$(echo \\"$INPUTS_TESTING_STD\\"  | grep 'self5_isCreated')" ]] || exit 47
+          [[ -z "$(echo \\"$INPUTS_TESTING_STD\\"  | grep 'self5_isLocked')" ]] || exit 48
 
           ARTIFACTS_ONE_STD='${{ steps.artifacts-1.outputs.std }}'
           printf "\n=======================\nartifacts-1 stdout\n========================\n$ARTIFACTS_ONE_STD"
-          [[ ! -z "$(echo \"$ARTIFACTS_ONE_STD\" | head -n 1)" ]] || exit 50
-          [[ ! -z "$(echo \"$ARTIFACTS_ONE_STD\"  | grep 'Created and uploaded artifact test-artifact')" ]] || exit 51
-          [[ ! -z "$(echo \"$ARTIFACTS_ONE_STD\"  | grep 'Archive contents:.*/test1.*/test2.*/test3')" ]] || exit 52
-          [[ ! -z "$(echo \"$ARTIFACTS_ONE_STD\"   | grep 'self6_isPost=true')" ]] || exit 53
-          [[ ! -z "$(echo \"$ARTIFACTS_ONE_STD\"   | grep 'self6_isCreated=true')" ]] || exit 54
-          [[ ! -z "$(echo \"$ARTIFACTS_ONE_STD\"   | grep 'self6_isLocked=false')" ]] || exit 55
+          [[ ! -z "$(echo \\"$ARTIFACTS_ONE_STD\\" | head -n 1)" ]] || exit 50
+          [[ ! -z "$(echo \\"$ARTIFACTS_ONE_STD\\"  | grep 'Created and uploaded artifact test-artifact')" ]] || exit 51
+          [[ ! -z "$(echo \\"$ARTIFACTS_ONE_STD\\"  | grep 'Archive contents:.*/test1.*/test2.*/test3')" ]] || exit 52
+          [[ ! -z "$(echo \\"$ARTIFACTS_ONE_STD\\"   | grep 'self6_isPost=true')" ]] || exit 53
+          [[ ! -z "$(echo \\"$ARTIFACTS_ONE_STD\\"   | grep 'self6_isCreated=true')" ]] || exit 54
+          [[ ! -z "$(echo \\"$ARTIFACTS_ONE_STD\\"   | grep 'self6_isLocked=false')" ]] || exit 55
 
           true
               
@@ -179,7 +191,7 @@ jobs:
         id: pull-test-2
         uses: ./
         with:
-          anka-template: "10.15.4"
+          anka-template: "10.15.5"
           anka-tag: "base:port-forward-22"
           commands: |
             env
@@ -193,7 +205,7 @@ jobs:
         run: |
           PULL_TEST_STD='${{ steps.pull-test-2.outputs.std }}'
           printf "\n=======================\npull test std\n========================\n${{ steps.pull-test-2.outputs.std }}"
-          [[ ! -z "$(echo $PULL_TEST_STD | head -n 1)" ]] || exit 100
-          [[ ! -z "$(echo $PULL_TEST_STD | grep 'Lock file /tmp/registry-pull-lock-10.15.4 found')" ]] || exit 101
+          [[ ! -z "$(echo \\"$PULL_TEST_STD\\" | head -n 1)" ]] || exit 100
+          [[ ! -z "$(echo \\"$PULL_TEST_STD\\" | grep 'Lock file /tmp/registry-pull-lock-10.15.5 found')" ]] || exit 101
           
           true

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 ## Using the (BETA) Anka GitHub Action
 
-1. Install the [Anka Virtualization CLI](https://github.com/veertuinc/getting-started#initial-setup) onto a macOS host machine. You'll need a [Template and Tag](https://github.com/veertuinc/getting-started#create-templatebash) generated.
-1. Install and ensure you have registered a shared (org level; found under org settings/actions) _or_ project specific self-hosted runner (found under repo settings/actions) with GitHub. These runners need to be running on the host machines you run your Anka Virtualization CLI.
-1. Include a `.github/workflows/{whatever}.yml` in your repo
-2. Make sure to set your mapping key `uses:` to `veertuinc/anka-vm-github-action@vX.X.X`
-3. There are a few required key/values you need to include under `with:`: `anka-template` and `commands` (see the Inputs section for more information)
+1. Install the [Anka Build Virtualization Software](https://github.com/veertuinc/getting-started#initial-setup) onto a macOS host machine. 
+    - You'll also need an [Anka Template and Tag](https://ankadocs.veertu.com/docs/getting-started/creating-your-first-vm/#understanding-vm-templates-tags-and-disk-usage) (our [getting started repo's create-template script](https://github.com/veertuinc/getting-started/blob/master/ANKA_BUILD_CLOUD/create-template.bash))
+2. Install and ensure you have registered a shared (org level; found under org settings/actions) _or_ project specific self-hosted runner (found under repo settings/actions) with GitHub. These runners need to be running on the host machines you run your Anka Virtualization CLI.
+3. Include a `.github/workflows/{whatever}.yml` in your repo
+4. Make sure to set your mapping key `uses:` to `veertuinc/anka-vm-github-action@vX.X.X`
+5. There are a few required key/values you need to include under `with:`: `anka-template` and `commands` (see the Inputs section for more information)
 
 ```yaml
 name: My Project's CI/CD
@@ -20,19 +21,25 @@ jobs:
         id: build
         uses: veertuinc/anka-vm-github-action@v1.2.0-beta
         with:
-          anka-template: "10.15.4"
+          anka-template: "10.15.5"
           anka-tag: "base:port-forward-22:xcode11-v1"
           anka-run-options: "--env"
           commands: |
-            echo "Starting build process"
-            ./build.sh && \
+            echo "Starting my job!" && \
+            ./prepare.sh
+            COMMAND_OUTPUT=\$(./gradlew test)
+            cat << EOF > /private/var/tmp/ankafs.0/log
+              \$COMMAND_OUTPUT
+              echo "Adding \\\$COMMAND_OUTPUT to /private/var/tmp/ankafs.0/log so it's available on the host $(hostname)"
+              \$(./gradlew build)
+            EOF
             ./cleanup.sh
           artifacts: |
             log.txt
             build/binaryfile-v1
 ```
 
-The above example will clone your project repo to the github action runner's working directory, pull the Template `10.15.4` and Tag `base:port-forward-22:xcode11-v1` from the Registry, prepare an Anka VM using that Template and Tag, execute the commands inside of the VM ensuring Environment Variables are passed in with `anka-run-options: "--env"`, and then upload artifacts `./log.txt` and `./build/binaryfile-v1` from the current directory (which is mounted by default into the VM).
+The above example will clone your project repo to the github action runner's working directory, pull the Template `10.15.5` and Tag `base:port-forward-22:xcode11-v1` from the Registry, prepare an Anka VM using that Template and Tag, execute the commands inside of the VM ensuring Environment Variables are passed in with `anka-run-options: "--env"`, and then upload artifacts `./log.txt` and `./build/binaryfile-v1` from the current directory (which is mounted by default into the VM).
 
 **Build and test time can be significantly impacted by the default host -> guest mount.** It's suggested that you use `anka-run-options: "--wait-network --wait-time --no-volume"` and then git clone your repo inside of `commands:`. Or, if you need to upload artifacts (requires they exist on the host), just cd out of the mounted directory (`/private/var/tmp/ankafs.0`) inside of the VM and then do the git clone so you can execute your builds and tests. This allows you to then move the files you want to upload as an artifact back into the mounted directory so they are seen on the host.**
 
@@ -44,9 +51,20 @@ These are defined under the `with:` mapping key inside of your workflow yaml.
 - **Name or UUID of your Anka Template**
 #### `commands` (multi-line string or regular string) (required)
 - **Commands you wish to run inside of the Anka VM**
-- You can use `commands: |` for multi-line input or a simple string
-- You need to escape double quotes `\"`
-- You need to escape any dollar signs `\$` so that it doesn't interpolate from the host side. Unless of course you wish to pass in something from the host into the VM.
+- You can use `commands: |` for multi-line input OR, you can just use a single line string `commands: "echo 123"`
+- When interpolating in a **multi-line string** (`commands: |`), be sure to use the proper amount of escapes for the desired effect:
+    ```bash
+    \\\$(echo $HOME)
+    \\\$(echo \$HOME)
+    \\\$(echo \\\$HOME)
+    ```
+    will result in...
+    ```bash
+    $(echo /Users/nathanpierce) # HOST level env was interpolated
+    $(echo /Users/anka)         # GUEST level env was interpolated
+    $(echo $HOME)               # No interpolation
+    ```
+- When interpolating in a **regular string** (`commands: "echo 123"`), be sure to use the proper amount of escapes as well, but add one extra due to the extra quotes.
 #### `anka-tag` (string) (optional)
 - **Name of Anka Tag**
 - Defaults to latest tag
@@ -108,7 +126,7 @@ jobs:
         id: pull-test-2
         uses: veertuinc/anka-vm-github-action@v1.2.0-beta
         with:
-          anka-template: "10.15.4"
+          anka-template: "10.15.5"
           anka-tag: "base:port-forward-22"
           commands: |
             env
@@ -122,8 +140,8 @@ jobs:
         run: |
           PULL_TEST_STD="${{ steps.pull-test-2.outputs.std }}"
           printf "pull test std ========================\n$PULL_TEST_STD"
-          [[ ! -z "$(echo \"$PULL_TEST_STD\" | head -n 1)" ]] || exit 50
-          [[ ! -z "$(echo \"$PULL_TEST_STD\" | grep 'Lock file /tmp/registry-pull-lock-10.15.4 found')" ]] || exit 51
+          [[ ! -z "$(echo \\"$PULL_TEST_STD\\" | head -n 1)" ]] || exit 50
+          [[ ! -z "$(echo \\"$PULL_TEST_STD\\" | grep 'Lock file /tmp/registry-pull-lock-10.15.5 found')" ]] || exit 51
           true
 ```
 
@@ -147,9 +165,14 @@ There are two types of tests we perform:
 
 2. Functional testing using a workflow yaml (not in this repo)
 
+### Building
+
+```bash 
+npm run package
+```
+
 ### TO-DO
 - Figure out how to handle agent lost situations (steps just run indefinitely)
 - Support multiple artifacts and files for those artifacts
 - Better tests with mocks so we can avoid so much functional testing
-- Execution of anka run should happen with `anka run template sh` and then passing into STDIN
 - Clone within VM (with skip-clone inputs)

--- a/dist/index.js
+++ b/dist/index.js
@@ -1044,7 +1044,8 @@ async function ankaRun(ankaVMLabel,ankaRunOptions,ankaCommands,hostCommandOption
   if (typeof(ankaRunOptions) === "undefined" || ankaRunOptions.length === 0) {
     ankaRunOptions = "--wait-network --wait-time"
   }
-  await nodeCommands(`anka run ${ankaRunOptions} ${ankaVMLabel} bash -c \"${ankaCommands}\"`,hostCommandOptions,STD)
+  // So we can use bash -s + HEREDOC, we need to add proper newlines to commands
+  await nodeCommands(`anka run ${ankaRunOptions} ${ankaVMLabel} bash -s << COMMANDS\n${ankaCommands}\nCOMMANDS`,hostCommandOptions,STD)
 }
 module.exports.ankaRun = ankaRun;
 
@@ -2087,7 +2088,6 @@ async function run() {
     //// Start the VM
     await prepare.ankaStart(ankaVMLabel,ankaStartOptions,hostCommandOptions);
     /// Run commands inside VM
-    console.log(`Running commands inside of Anka VM ==============\nAnka run options: ${ankaRunOptions}\n${ankaCommands}\n==============\n`)
     await execute.ankaRun(ankaVMLabel,ankaRunOptions,ankaCommands,hostCommandOptions);
     if (hostPostCommands) {
       await execute.nodeCommands(hostPostCommands,hostCommandOptions,execute.STD);

--- a/execute.js
+++ b/execute.js
@@ -45,6 +45,7 @@ async function ankaRun(ankaVMLabel,ankaRunOptions,ankaCommands,hostCommandOption
   if (typeof(ankaRunOptions) === "undefined" || ankaRunOptions.length === 0) {
     ankaRunOptions = "--wait-network --wait-time"
   }
-  await nodeCommands(`anka run ${ankaRunOptions} ${ankaVMLabel} bash -c \"${ankaCommands}\"`,hostCommandOptions,STD)
+  // So we can use bash -s + HEREDOC, we need to add proper newlines to commands
+  await nodeCommands(`anka run ${ankaRunOptions} ${ankaVMLabel} bash -s << COMMANDS\n${ankaCommands}\nCOMMANDS`,hostCommandOptions,STD)
 }
 module.exports.ankaRun = ankaRun;

--- a/index.js
+++ b/index.js
@@ -46,7 +46,6 @@ async function run() {
     //// Start the VM
     await prepare.ankaStart(ankaVMLabel,ankaStartOptions,hostCommandOptions);
     /// Run commands inside VM
-    console.log(`Running commands inside of Anka VM ==============\nAnka run options: ${ankaRunOptions}\n${ankaCommands}\n==============\n`)
     await execute.ankaRun(ankaVMLabel,ankaRunOptions,ankaCommands,hostCommandOptions);
     if (hostPostCommands) {
       await execute.nodeCommands(hostPostCommands,hostCommandOptions,execute.STD);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anka-vm-github-action",
-  "version": "1.0.0-beta",
+  "version": "1.3.0-beta",
   "description": "A GitHub Action for running commands within Anka VMs",
   "main": "index.js",
   "scripts": {

--- a/prepare.test.js
+++ b/prepare.test.js
@@ -18,18 +18,18 @@ describe('prepare functions', () => {
   }); // DESCRIBE
   describe('deleteLockFile', () => {
     afterEach(() => {
-      try{ fs.unlinkSync('/tmp/registry-pull-lock-10.15.4'); } catch(error) {}
+      try{ fs.unlinkSync('/tmp/registry-pull-lock-10.15.5'); } catch(error) {}
       core.exportVariable(`${process.env['GITHUB_ACTION']}_isLocked`, false)
     });
     test('file exists', async() => {
       core.exportVariable(`${process.env['GITHUB_ACTION']}_isLocked`, true)
-      fs.closeSync(fs.openSync('/tmp/registry-pull-lock-10.15.4', 'w'));
-      await prepare.deleteLockFile("10.15.4")
-      await expect(fs.existsSync("/tmp/registry-pull-lock-10.15.4")).toBe(false)
+      fs.closeSync(fs.openSync('/tmp/registry-pull-lock-10.15.5', 'w'));
+      await prepare.deleteLockFile("10.15.5")
+      await expect(fs.existsSync("/tmp/registry-pull-lock-10.15.5")).toBe(false)
     }); // TEST
     test('no file, no problem', async() => {
-      await prepare.deleteLockFile("10.15.4")
-      await expect(fs.existsSync("/tmp/registry-pull-lock-10.15.4")).toBe(false)
+      await prepare.deleteLockFile("10.15.5")
+      await expect(fs.existsSync("/tmp/registry-pull-lock-10.15.5")).toBe(false)
     }); // TEST
   }); // DESCRIBE
 });


### PR DESCRIPTION
Problem: Anka run commands use bash -c "COMMANDS HERE" and that requires users to escape quotes inside of COMMANDS HERE.

Solution: Use bash -s << EOF\nCOMMANDS HERE\nEOF to avoid bash -c